### PR TITLE
Remove approved-crashes from CrashManager

### DIFF
--- a/Classes/MSAICrashManagerPrivate.h
+++ b/Classes/MSAICrashManagerPrivate.h
@@ -29,7 +29,6 @@ should not need to set this delegate individually.
 @property (nonatomic, strong) NSFileManager *fileManager; //TODO remove when we refactor the persistence stuff out of crashmanager
 @property (nonatomic, strong) MSAIContext *appContext;
 @property (nonatomic, strong) NSMutableArray *crashFiles; //TODO remove when we refactor the persistence stuff out of crashmanager
-@property (nonatomic, strong) NSMutableDictionary *approvedCrashReports;
 @property (nonatomic, copy) NSString *settingsFile; //TODO remove when we refactor the persistence stuff out of crashmanager
 @property (nonatomic, copy) NSString *crashesDir; //TODO remove when we refactor the persistence stuff out of crashmanager
 @property (nonatomic, copy) NSString *lastCrashFilename;
@@ -54,8 +53,6 @@ should not need to set this delegate individually.
 
 - (void)handleCrashReport;
 
-- (NSString *)firstNotApprovedCrashReport;
-
 - (BOOL)hasPendingCrashReport;
 
 - (void)invokeDelayedProcessing;
@@ -65,10 +62,6 @@ should not need to set this delegate individually.
 - (void)createCrashReport;
 
 - (void)processCrashReportWithFilename:(NSString *)filename envelope:(MSAIEnvelope *)envelope;
-
-- (void)saveSettings;
-
-- (void)loadSettings;
 
 - (void)cleanCrashReports;
 
@@ -81,7 +74,7 @@ should not need to set this delegate individually.
 /**
 * by default, just logs the message
 *
-* can be overriden by subclasses to do their own error handling,
+* can be overridden by subclasses to do their own error handling,
 * e.g. to show UI
 *
 * @param error NSError

--- a/Support/AppInsightsTests/MSAICrashManagerTests.m
+++ b/Support/AppInsightsTests/MSAICrashManagerTests.m
@@ -94,11 +94,6 @@
   assertThatBool([_sut hasPendingCrashReport], equalToBool(NO));
 }
 
-- (void)testFirstNotApprovedCrashReportWithNoFiles {
-  _sut.isCrashManagerDisabled = NO;
-  assertThat([_sut firstNotApprovedCrashReport], equalTo(nil));
-}
-
 - (void)testCreateCrashReportForAppKill {
   //handle app kill (FakeCrashReport
   [_sut createCrashReportForAppKill]; //just creates a fake crash report and hands it over to MSAIPersistence
@@ -148,7 +143,6 @@
   
   // No files at startup
   assertThatBool([_sut hasPendingCrashReport], equalToBool(NO));
-  assertThat([_sut firstNotApprovedCrashReport], equalTo(nil));
   
   [_sut invokeDelayedProcessing];
   
@@ -159,7 +153,6 @@
   
   // we should have 0 pending crash report
   assertThatBool([_sut hasPendingCrashReport], equalToBool(NO));
-  assertThat([_sut firstNotApprovedCrashReport], equalTo(nil));
   
   [_sut cleanCrashReports];
   
@@ -170,7 +163,6 @@
   
   // we should have now 1 pending crash report
   assertThatBool([_sut hasPendingCrashReport], equalToBool(YES));
-  assertThat([_sut firstNotApprovedCrashReport], notNilValue());
   
   [_sut cleanCrashReports];
 
@@ -181,7 +173,6 @@
   
   // we should have now 1 pending crash report
   assertThatBool([_sut hasPendingCrashReport], equalToBool(YES));
-  assertThat([_sut firstNotApprovedCrashReport], notNilValue());
   
   [_sut cleanCrashReports];
   


### PR DESCRIPTION
MSAICrashManager contained logic that is no longer required. Hockey had the feature that devs could decide to get the user's permission before each submitted crashreport. AppInsights doesn't have this feature, so logic related to "approved crashes" can be deleted.