### PR TITLE
Set a user ID in session context

### DIFF
--- a/Classes/AppInsights.h
+++ b/Classes/AppInsights.h
@@ -14,6 +14,9 @@
 #if MSAI_FEATURE_METRICS
 #import "MSAICategoryContainer.h"
 #import "MSAIMetricsManager.h"
+
+extern NSString *const __attribute__((unused)) kMSAIUserId;
+
 #endif /* MSAI_FEATURE_METRICS */
 
 // Notification message which AppInsightsManager is listening to, to retry requesting updated from the server

--- a/Classes/AppInsightsPrivate.m
+++ b/Classes/AppInsightsPrivate.m
@@ -3,3 +3,4 @@
 
 NSString *const kMSAICrashErrorDomain = @"MSAICrashReporterErrorDomain";
 NSString *const kMSAIErrorDomain = @"MSAIErrorDomain";
+NSString *const kMSAIUserId = @"com.microsoft.appinsights.userid";

--- a/Classes/MSAIAppInsights.m
+++ b/Classes/MSAIAppInsights.m
@@ -256,6 +256,14 @@ NSString *const kMSAIInstrumentationKey = @"MSAIInstrumentationKey";
   
   MSAIOperation *operationContext = [MSAIOperation new];
   MSAIUser *userContext = [MSAIUser new];
+  NSString *userId = [[NSUserDefaults standardUserDefaults] stringForKey:kMSAIUserId];
+  if (!userId || userId.length == 0) {
+    userId = msai_UUID();
+    [[NSUserDefaults standardUserDefaults] setObject:userId forKey:kMSAIUserId];
+    [[NSUserDefaults standardUserDefaults] synchronize];
+  }
+  userContext.userId = userId;
+  
   MSAILocation *locationContext = [MSAILocation new];
   
   //TODO: Add additional context data

--- a/Classes/MSAIAppInsights.m
+++ b/Classes/MSAIAppInsights.m
@@ -256,13 +256,8 @@ NSString *const kMSAIInstrumentationKey = @"MSAIInstrumentationKey";
   
   MSAIOperation *operationContext = [MSAIOperation new];
   MSAIUser *userContext = [MSAIUser new];
-  NSString *userId = [[NSUserDefaults standardUserDefaults] stringForKey:kMSAIUserId];
-  if (!userId || userId.length == 0) {
-    userId = msai_UUID();
-    [[NSUserDefaults standardUserDefaults] setObject:userId forKey:kMSAIUserId];
-    [[NSUserDefaults standardUserDefaults] synchronize];
-  }
-  userContext.userId = userId;
+  //This is the same as the device id right now but we don't see a point in differentiating between the two as of now.
+  userContext.userId = msai_appAnonID();
   
   MSAILocation *locationContext = [MSAILocation new];
   


### PR DESCRIPTION
This ID is ideally only set once per install and is used to anonymously identify a user and enable user based telemetry in the backend.