### PR TITLE
Use osVersionBuild instead of only version number

### DIFF
--- a/Classes/MSAIContext.m
+++ b/Classes/MSAIContext.m
@@ -18,7 +18,7 @@
     _deviceModel = msai_devicePlatform();
     _deviceType = msai_deviceType();
     _osName = msai_osName();
-    _osVersion = msai_osVersion();
+    _osVersion = msai_osVersionBuild();
     _appVersion = msai_appVersion();
   }
   return self;

--- a/Classes/MSAIHelper.h
+++ b/Classes/MSAIHelper.h
@@ -15,7 +15,7 @@ NSString *msai_appVersion(void);
 NSString *msai_devicePlatform(void);
 NSString *msai_deviceLanguage(void);
 NSString *msai_deviceLocale(void);
-NSString *msai_osVersion(void);
+NSString *msai_osVersionBuild(void);
 NSString *msai_osName(void);
 NSString *msai_deviceType(void);
 NSString *msai_screenSize(void);

--- a/Classes/MSAIHelper.m
+++ b/Classes/MSAIHelper.m
@@ -149,12 +149,14 @@ NSString *msai_osVersionBuild(void) {
    * may change after each iteration. */
   do {
     /* Fetch the expected length */
-    if ((ret = sysctlbyname("kern.osversion", NULL, &result_len, NULL, 0)) == -1)
+    if ((ret = sysctlbyname("kern.osversion", NULL, &result_len, NULL, 0)) == -1) {
       break;
+    }
     
     /* Allocate the destination buffer */
-    if (result != NULL)
+    if (result != NULL) {
       free(result);
+    }
     result = malloc(result_len);
     
     /* Fetch the value */
@@ -165,8 +167,9 @@ NSString *msai_osVersionBuild(void) {
   if (ret == -1) {
     int saved_errno = errno;
     
-    if (result != NULL)
+    if (result != NULL) {
       free(result);
+    }
     
     errno = saved_errno;
     return NULL;

--- a/Classes/MSAIHelper.m
+++ b/Classes/MSAIHelper.m
@@ -140,8 +140,44 @@ NSString *msai_encodeInstrumentationKey(NSString *inputString) {
   return (inputString ? msai_URLEncodedString(inputString) : msai_URLEncodedString(msai_mainBundleIdentifier()));
 }
 
-NSString *msai_osVersion(void){
-  return [[UIDevice currentDevice] systemVersion];
+NSString *msai_osVersionBuild(void) {
+  void *result = NULL;
+  size_t result_len = 0;
+  int ret;
+  
+  /* If our buffer is too small after allocation, loop until it succeeds -- the requested destination size
+   * may change after each iteration. */
+  do {
+    /* Fetch the expected length */
+    if ((ret = sysctlbyname("kern.osversion", NULL, &result_len, NULL, 0)) == -1)
+      break;
+    
+    /* Allocate the destination buffer */
+    if (result != NULL)
+      free(result);
+    result = malloc(result_len);
+    
+    /* Fetch the value */
+    ret = sysctlbyname("kern.osversion", result, &result_len, NULL, 0);
+  } while (ret == -1 && errno == ENOMEM);
+  
+  /* Handle failure */
+  if (ret == -1) {
+    int saved_errno = errno;
+    
+    if (result != NULL)
+      free(result);
+    
+    errno = saved_errno;
+    return NULL;
+  }
+  
+  NSString *osBuild = [NSString stringWithCString:result encoding:NSUTF8StringEncoding];
+  free(result);
+  
+  NSString *osVersion = [[UIDevice currentDevice] systemVersion];
+  
+  return [NSString stringWithFormat:@"%@(%@)", osVersion, osBuild];
 }
 
 NSString *msai_osName(void){

--- a/Support/AppInsightsTests/MSAIHelperTests.m
+++ b/Support/AppInsightsTests/MSAIHelperTests.m
@@ -40,7 +40,7 @@
 }
 
 - (void)testOsVersion {
-  NSString *resultString = msai_osVersion();
+  NSString *resultString = msai_osVersionBuild();
   assertThat(resultString, notNilValue());
   assertThatFloat([resultString floatValue], greaterThan(@(0.0)));
 }


### PR DESCRIPTION
This allows for a more accurate differentiation between OS versions, e.g. like this: `8.2(12D508)`
Note that this is also what we're already sending as part of the crash reports.