### PR TITLE
Remove legacy code for pre-iOS6

### DIFF
--- a/Classes/MSAIHelper.h
+++ b/Classes/MSAIHelper.h
@@ -24,7 +24,6 @@ NSString *msai_sdkBuild(void);
 NSString *msai_dec(void);
 NSString *msai_mainBundleIdentifier(void);
 NSString *msai_encodeInstrumentationKey(NSString *inputString);
-NSString *msai_UUIDPreiOS6(void);
 NSString *msai_UUID(void);
 NSString *msai_appAnonID(void);
 BOOL msai_isPreiOS7Environment(void);

--- a/Classes/MSAIHelper.m
+++ b/Classes/MSAIHelper.m
@@ -248,26 +248,8 @@ NSString *msai_deviceLocale(void) {
   return [locale objectForKey:NSLocaleIdentifier];
 }
 
-NSString *msai_UUIDPreiOS6(void) {
-  // Create a new UUID
-  CFUUIDRef uuidObj = CFUUIDCreate(nil);
-  
-  // Get the string representation of the UUID
-  NSString *resultUUID = (NSString*)CFBridgingRelease(CFUUIDCreateString(nil, uuidObj));
-  CFRelease(uuidObj);
-  
-  return resultUUID;
-}
-
 NSString *msai_UUID(void) {
-  NSString *resultUUID = nil;
-  
-  id uuidClass = NSClassFromString(@"NSUUID");
-  if (uuidClass) {
-    resultUUID = [[NSUUID UUID] UUIDString];
-  } else {
-    resultUUID = msai_UUIDPreiOS6();
-  }
+  NSString *resultUUID = [[NSUUID UUID] UUIDString];
   
   return resultUUID;
 }

--- a/Support/AppInsightsTests/MSAIHelperTests.m
+++ b/Support/AppInsightsTests/MSAIHelperTests.m
@@ -70,12 +70,6 @@
   assertThatInteger([resultString intValue], greaterThan(@(0)));
 }
 
-- (void)testUUIDPreiOS6 {
-  NSString *resultString = msai_UUIDPreiOS6();
-  assertThat(resultString, notNilValue());
-  assertThatInteger([resultString length], equalToInteger(36));
-}
-
 - (void)testUUID {
   NSString *resultString = msai_UUID();
   assertThat(resultString, notNilValue());


### PR DESCRIPTION
We don't support iOS 5 or earlier so this is technical debt and should be removed